### PR TITLE
Intergrate Luma API and GitHub Workflow

### DIFF
--- a/.github/update-events.yml
+++ b/.github/update-events.yml
@@ -1,0 +1,43 @@
+name: Update events calendar
+
+on:
+  schedule:
+    - cron: "0 7 * * *" # every day at midnight Vancouver time
+  workflow_dispatch:
+
+jobs:
+  scrape-events:
+    runs-on: ubuntu-latest
+    env:
+      # necessary for using `gh` cli
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: 'npm'
+      # scrapes luma and updates events.json
+      - name: Run events scraping script
+        run: node index.js
+      # check if events.json has changed, and if so, commit, push, and trigger deploy workflow
+      - name: Configure Git
+        run: |
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "GitHub Actions"
+      - name: Commit and push changes
+        run: |
+          if git diff --exit-code events.json; then
+            echo "No event updates"
+          else 
+            echo "Changes detected - committing new events.json"
+            git add events.json
+            git commit -m "Update events calendar [automated]"
+            git push
+
+            # workflows do not trigger other workflows by default when using the default auth token
+            # so instead we will trigger a new deploy manually
+            gh workflow run deploy.yml
+          fi

--- a/events.json
+++ b/events.json
@@ -1,0 +1,687 @@
+{
+  "entries": [
+    {
+      "api_id": "calev-uW5h3m7XsS2QztJ",
+      "event": {
+        "api_id": "evt-fG1PBHIgWArmkrD",
+        "calendar_api_id": "cal-eRivKmWDsR2bxYq",
+        "cover_url": "https://images.lumacdn.com/event-covers/tj/1c6be007-a644-4215-adc1-2f4a0d605bf8.png",
+        "end_at": "2026-01-24T03:30:00.000Z",
+        "event_type": "independent",
+        "hide_rsvp": false,
+        "location_type": "offline",
+        "name": "AWS re:Invent re:Cap",
+        "one_to_one": true,
+        "recurrence_id": null,
+        "show_guest_list": true,
+        "start_at": "2026-01-24T01:30:00.000Z",
+        "timezone": "America/Vancouver",
+        "url": "f0uc6rr2",
+        "user_api_id": "usr-g6FxZJfODUaVboL",
+        "visibility": "public",
+        "virtual_info": {
+          "has_access": false
+        },
+        "geo_address_info": {
+          "city": "Vancouver",
+          "type": "google",
+          "region": "British Columbia",
+          "address": "510 W Georgia St 14th floor",
+          "country": "Canada",
+          "place_id": "Ejo1MTAgVyBHZW9yZ2lhIFN0IDE0dGggZmxvb3IsIFZhbmNvdXZlciwgQkMgVjZCIDBNMywgQ2FuYWRhIiYaJAoWChQKEgnrsCflfnGGVBFJWlCB0b86uBIKMTR0aCBmbG9vcg",
+          "localized": null,
+          "city_state": "Vancouver, British Columbia",
+          "description": "Wait in the lobby for someone to escort you up - please arrive before 6pm - bring a government-issued photo ID or student ID",
+          "sublocality": "Central Vancouver",
+          "country_code": "CA",
+          "full_address": "510 W Georgia St 14th floor, Vancouver, BC V6B 0M3, Canada",
+          "short_address": "510 W Georgia St 14th floor, Vancouver",
+          "apple_maps_place_id": null,
+          "mode": "shown"
+        },
+        "geo_address_visibility": "public",
+        "coordinate": {
+          "longitude": -123.11699940000001,
+          "latitude": 49.280990300000006
+        },
+        "waitlist_enabled": false,
+        "waitlist_status": "disabled"
+      },
+      "cover_image": {
+        "vibrant_color": null,
+        "colors": [
+          "#100f05",
+          "#f8f5f4",
+          "#b37531",
+          "#782b05"
+        ],
+        "palette": {
+          "neutral": [
+            {
+              "color": "#110f05",
+              "percentage": 31.19
+            },
+            {
+              "color": "#f9f6f4",
+              "percentage": 7.17
+            }
+          ],
+          "vibrant": [
+            {
+              "color": "#b37532",
+              "percentage": 6.4
+            },
+            {
+              "color": "#772a06",
+              "percentage": 5.01
+            }
+          ]
+        }
+      },
+      "calendar": {
+        "access_level": "public",
+        "api_id": "cal-eRivKmWDsR2bxYq",
+        "avatar_url": "https://images.lumacdn.com/calendars/cs/fb32f931-39df-448a-8768-0b4ee27ce169",
+        "coordinate": {
+          "longitude": -123.120738,
+          "latitude": 49.282729
+        },
+        "cover_image_url": "https://images.unsplash.com/photo-1560439514-4e9645039924?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wxMjQyMjF8MHwxfHNlYXJjaHwyfHxuZXR3b3JraW5nfGVufDB8fHx8MTcyMjI5MjA3Mnwy&ixlib=rb-4.0.3&q=80&w=1080",
+        "description_short": "Amazon AWS, Microsoft Azure and Google GCP events in Canada",
+        "event_submission_restriction": "open",
+        "geo_city": "Vancouver",
+        "geo_country": "Canada",
+        "geo_region": "British Columbia",
+        "google_measurement_id": null,
+        "instagram_handle": null,
+        "is_blocked": false,
+        "launch_status": "launched",
+        "linkedin_handle": null,
+        "luma_plus_active": true,
+        "meta_pixel_id": null,
+        "name": "Cloud Events",
+        "personal_user_api_id": null,
+        "refund_policy": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [
+                {
+                  "text": "No refunds. No Exchanges.",
+                  "type": "text"
+                }
+              ]
+            }
+          ]
+        },
+        "slug": "CloudCanada",
+        "social_image_url": null,
+        "stripe_account_id": "acct_1PxuTSE3uYeEs2Ai",
+        "tax_config": null,
+        "tiktok_handle": null,
+        "timezone": "America/Vancouver",
+        "tint_color": "#ffedc7",
+        "track_meta_ads_from_luma": false,
+        "twitter_handle": null,
+        "verified_at": "2024-06-12T21:30:46.314Z",
+        "website": "https://www.PublicCloud.ninja",
+        "youtube_handle": null,
+        "is_personal": false,
+        "personal_user": null
+      },
+      "start_at": "2026-01-24T01:30:00.000Z",
+      "hosts": [
+        {
+          "name": "Matt",
+          "api_id": "usr-g6FxZJfODUaVboL",
+          "website": "https://www.mattcarolan.com",
+          "timezone": "America/Vancouver",
+          "username": "MattCloud",
+          "bio_short": null,
+          "avatar_url": "https://images.lumacdn.com/avatars/n0/1cf35698-8753-45fc-9bb7-ad9e6c427b85",
+          "is_verified": false,
+          "tiktok_handle": null,
+          "last_online_at": "2026-01-21T04:23:26.723Z",
+          "twitter_handle": null,
+          "youtube_handle": "PublicCloudNinja",
+          "linkedin_handle": "/in/matthewcarolan",
+          "instagram_handle": "PublicCloudNinja"
+        }
+      ],
+      "guest_count": 202,
+      "ticket_count": 202,
+      "ticket_info": {
+        "price": null,
+        "is_free": true,
+        "max_price": null,
+        "is_sold_out": false,
+        "spots_remaining": null,
+        "is_near_capacity": false,
+        "require_approval": false,
+        "currency_info": null
+      },
+      "featured_guests": [
+        {
+          "api_id": "usr-vfeScRlvdtiXRiK",
+          "avatar_url": "https://images.lumacdn.com/avatars/6s/dd6d8bf9-bc9e-497c-bd8f-e72fc4aab114",
+          "bio_short": null,
+          "instagram_handle": null,
+          "is_verified": false,
+          "last_online_at": "2026-01-21T05:55:43.824Z",
+          "linkedin_handle": "/in/a-huaman",
+          "name": "Alejandra Huaman",
+          "tiktok_handle": null,
+          "timezone": "America/Vancouver",
+          "twitter_handle": null,
+          "username": null,
+          "website": null,
+          "youtube_handle": ""
+        },
+        {
+          "api_id": "usr-YjcqlKCmTxmcOxD",
+          "avatar_url": "https://images.lumacdn.com/avatars/0i/c18cd23d-4d82-4edf-9919-2065231786f2.jpg",
+          "bio_short": null,
+          "instagram_handle": "bryantiskandar",
+          "is_verified": false,
+          "last_online_at": "2026-01-21T05:44:30.713Z",
+          "linkedin_handle": "/in/bryantiskandar",
+          "name": "Bryant Iskandar",
+          "tiktok_handle": null,
+          "timezone": "America/Los_Angeles",
+          "twitter_handle": null,
+          "username": "bryantiskandar",
+          "website": null,
+          "youtube_handle": ""
+        },
+        {
+          "api_id": "usr-w59Ae1BPe162BBV",
+          "avatar_url": "https://images.lumacdn.com/avatars/nt/d327207e-cd0f-4132-9b8d-fda29598dc0f.jpg",
+          "bio_short": "",
+          "instagram_handle": "alexandra_consciousness",
+          "is_verified": false,
+          "last_online_at": "2026-01-21T01:05:41.878Z",
+          "linkedin_handle": "/in/alexandrasipyachova",
+          "name": "Alexandra Sypiachova",
+          "tiktok_handle": null,
+          "timezone": "America/Vancouver",
+          "twitter_handle": null,
+          "username": "alexandrasyp",
+          "website": null,
+          "youtube_handle": ""
+        },
+        {
+          "api_id": "usr-5pvv7CXuSwFaG44",
+          "avatar_url": "https://images.lumacdn.com/avatars/97/abfda9d3-c5bc-461d-8d6f-8eb5a86159ec.png",
+          "bio_short": "",
+          "instagram_handle": null,
+          "is_verified": false,
+          "last_online_at": "2026-01-20T19:19:57.470Z",
+          "linkedin_handle": null,
+          "name": "Andrew",
+          "tiktok_handle": null,
+          "timezone": "America/Vancouver",
+          "twitter_handle": null,
+          "username": null,
+          "website": null,
+          "youtube_handle": null
+        },
+        {
+          "api_id": "usr-icwyrtsQ3XhWwM2",
+          "avatar_url": "https://images.lumacdn.com/avatars/am/a5b335fe-4f75-4e3a-b404-d3ae8ac4f5c0",
+          "bio_short": "",
+          "instagram_handle": null,
+          "is_verified": false,
+          "last_online_at": "2026-01-21T01:16:36.529Z",
+          "linkedin_handle": "/in/melaniia",
+          "name": "Melaniia Volkodav",
+          "tiktok_handle": null,
+          "timezone": "America/Vancouver",
+          "twitter_handle": "email",
+          "username": null,
+          "website": null,
+          "youtube_handle": ""
+        },
+        {
+          "api_id": "usr-HyJm9S4VhLccy3y",
+          "avatar_url": "https://images.lumacdn.com/avatars/mf/007b33eb-3c1e-4585-904e-b113c4c01c08.jpg",
+          "bio_short": null,
+          "instagram_handle": null,
+          "is_verified": false,
+          "last_online_at": "2026-01-19T21:22:20.785Z",
+          "linkedin_handle": null,
+          "name": "Gaël Jollivet",
+          "tiktok_handle": null,
+          "timezone": "America/Vancouver",
+          "twitter_handle": null,
+          "username": "gaeljollivet",
+          "website": null,
+          "youtube_handle": ""
+        },
+        {
+          "api_id": "usr-EnhJAE2EvQoXYcM",
+          "avatar_url": "https://images.lumacdn.com/avatars/m4/770f0aa0-6ea4-4ce4-ac83-cc0c580e8fd8.png",
+          "bio_short": "Head of BC @ Women in Tech Canada",
+          "instagram_handle": null,
+          "is_verified": false,
+          "last_online_at": "2026-01-21T04:20:37.316Z",
+          "linkedin_handle": "/in/bibschan",
+          "name": "Bibiana Souza",
+          "tiktok_handle": null,
+          "timezone": "America/Vancouver",
+          "twitter_handle": null,
+          "username": "bibschan",
+          "website": null,
+          "youtube_handle": ""
+        },
+        {
+          "api_id": "usr-r7m2rFKV5S2BdQ0",
+          "avatar_url": "https://images.lumacdn.com/avatars/zm/62e08895-384e-4677-b221-9f583dd7b79d.jpg",
+          "bio_short": null,
+          "instagram_handle": null,
+          "is_verified": false,
+          "last_online_at": "2025-12-11T16:08:53.957Z",
+          "linkedin_handle": "/in/lionello",
+          "name": "Lio Lunesu",
+          "tiktok_handle": null,
+          "timezone": "America/Los_Angeles",
+          "twitter_handle": "in",
+          "username": "lionello",
+          "website": null,
+          "youtube_handle": ""
+        },
+        {
+          "api_id": "usr-KJfzEBtcvZ1wFFf",
+          "avatar_url": "https://images.lumacdn.com/avatars/qd/4b6a4f08-ac84-4d93-ab7c-579000eba00a",
+          "bio_short": null,
+          "instagram_handle": null,
+          "is_verified": false,
+          "last_online_at": "2026-01-16T21:09:54.524Z",
+          "linkedin_handle": "/in/lubadelegan",
+          "name": "Liubov",
+          "tiktok_handle": null,
+          "timezone": "America/Vancouver",
+          "twitter_handle": null,
+          "username": null,
+          "website": null,
+          "youtube_handle": ""
+        },
+        {
+          "api_id": "usr-T9F6ByTAbMCqaNp",
+          "avatar_url": "https://images.lumacdn.com/avatars/zz/194c3588-edc6-49ba-915a-b1e00359be5e.jpg",
+          "bio_short": "",
+          "instagram_handle": null,
+          "is_verified": false,
+          "last_online_at": "2026-01-16T19:27:09.169Z",
+          "linkedin_handle": "/in/asamisuzukid",
+          "name": "Asami",
+          "tiktok_handle": null,
+          "timezone": "America/Vancouver",
+          "twitter_handle": null,
+          "username": null,
+          "website": null,
+          "youtube_handle": ""
+        }
+      ],
+      "role": null,
+      "waitlist_active": false,
+      "featured_city": {
+        "api_id": "discplace-4fa7ldlAkBTTivm",
+        "name": "Vancouver",
+        "slug": "vancouver"
+      },
+      "calendar_api_id": "cal-eRivKmWDsR2bxYq",
+      "is_manager": true,
+      "platform": "luma",
+      "status": "approved",
+      "submitted_by_user_api_id": "usr-g6FxZJfODUaVboL",
+      "tags": []
+    },
+    {
+      "api_id": "calev-VeFuf1sXJyXsBSM",
+      "event": {
+        "api_id": "evt-29l5EDyiSF3WNaf",
+        "calendar_api_id": "cal-eRivKmWDsR2bxYq",
+        "cover_url": "https://images.lumacdn.com/event-covers/ly/ce80f4ef-7b27-4f30-84d4-9253e7479b81.png",
+        "end_at": "2026-05-02T03:00:00.000Z",
+        "event_type": "independent",
+        "hide_rsvp": false,
+        "location_type": "offline",
+        "name": "Vancouver Cloud Summit 2026",
+        "one_to_one": true,
+        "recurrence_id": null,
+        "show_guest_list": false,
+        "start_at": "2026-05-01T22:00:00.000Z",
+        "timezone": "America/Vancouver",
+        "url": "cloudsummit26",
+        "user_api_id": "usr-g6FxZJfODUaVboL",
+        "visibility": "public",
+        "virtual_info": {
+          "has_access": false
+        },
+        "geo_address_info": {
+          "city": "Vancouver",
+          "type": "google",
+          "region": "British Columbia",
+          "address": "Science World",
+          "country": "Canada",
+          "place_id": "ChIJnZHwi2NxhlQRN3CYHzc3giE",
+          "city_state": "Vancouver, British Columbia",
+          "description": "",
+          "country_code": "CA",
+          "full_address": "Science World, 1455 Quebec St, Vancouver, BC V6A 3Z7, Canada",
+          "apple_maps_place_id": "IC49A9EEBE4CE0462",
+          "mode": "shown"
+        },
+        "geo_address_visibility": "public",
+        "coordinate": {
+          "longitude": -123.10383399999999,
+          "latitude": 49.273376
+        },
+        "waitlist_enabled": false,
+        "waitlist_status": "disabled"
+      },
+      "cover_image": {
+        "vibrant_color": null,
+        "colors": [
+          "#ffffff",
+          "#221e1f",
+          "#6eaedf"
+        ],
+        "palette": {
+          "neutral": [
+            {
+              "color": "#ffffff",
+              "percentage": 88.47
+            },
+            {
+              "color": "#221e1f",
+              "percentage": 6.34
+            }
+          ],
+          "vibrant": [
+            {
+              "color": "#6eaede",
+              "percentage": 4.02
+            }
+          ]
+        }
+      },
+      "calendar": {
+        "access_level": "public",
+        "api_id": "cal-eRivKmWDsR2bxYq",
+        "avatar_url": "https://images.lumacdn.com/calendars/cs/fb32f931-39df-448a-8768-0b4ee27ce169",
+        "coordinate": {
+          "longitude": -123.120738,
+          "latitude": 49.282729
+        },
+        "cover_image_url": "https://images.unsplash.com/photo-1560439514-4e9645039924?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wxMjQyMjF8MHwxfHNlYXJjaHwyfHxuZXR3b3JraW5nfGVufDB8fHx8MTcyMjI5MjA3Mnwy&ixlib=rb-4.0.3&q=80&w=1080",
+        "description_short": "Amazon AWS, Microsoft Azure and Google GCP events in Canada",
+        "event_submission_restriction": "open",
+        "geo_city": "Vancouver",
+        "geo_country": "Canada",
+        "geo_region": "British Columbia",
+        "google_measurement_id": null,
+        "instagram_handle": null,
+        "is_blocked": false,
+        "launch_status": "launched",
+        "linkedin_handle": null,
+        "luma_plus_active": true,
+        "meta_pixel_id": null,
+        "name": "Cloud Events",
+        "personal_user_api_id": null,
+        "refund_policy": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [
+                {
+                  "text": "No refunds. No Exchanges.",
+                  "type": "text"
+                }
+              ]
+            }
+          ]
+        },
+        "slug": "CloudCanada",
+        "social_image_url": null,
+        "stripe_account_id": "acct_1PxuTSE3uYeEs2Ai",
+        "tax_config": null,
+        "tiktok_handle": null,
+        "timezone": "America/Vancouver",
+        "tint_color": "#ffedc7",
+        "track_meta_ads_from_luma": false,
+        "twitter_handle": null,
+        "verified_at": "2024-06-12T21:30:46.314Z",
+        "website": "https://www.PublicCloud.ninja",
+        "youtube_handle": null,
+        "is_personal": false,
+        "personal_user": null
+      },
+      "start_at": "2026-05-01T22:00:00.000Z",
+      "hosts": [
+        {
+          "name": "Matt",
+          "api_id": "usr-g6FxZJfODUaVboL",
+          "website": "https://www.mattcarolan.com",
+          "timezone": "America/Vancouver",
+          "username": "MattCloud",
+          "bio_short": null,
+          "avatar_url": "https://images.lumacdn.com/avatars/n0/1cf35698-8753-45fc-9bb7-ad9e6c427b85",
+          "is_verified": false,
+          "tiktok_handle": null,
+          "last_online_at": "2026-01-21T04:23:26.723Z",
+          "twitter_handle": null,
+          "youtube_handle": "PublicCloudNinja",
+          "linkedin_handle": "/in/matthewcarolan",
+          "instagram_handle": "PublicCloudNinja"
+        }
+      ],
+      "guest_count": 0,
+      "ticket_count": 0,
+      "ticket_info": {
+        "price": {
+          "cents": 4900,
+          "currency": "cad",
+          "is_flexible": false
+        },
+        "is_free": false,
+        "max_price": null,
+        "is_sold_out": false,
+        "spots_remaining": null,
+        "is_near_capacity": false,
+        "require_approval": false,
+        "currency_info": {
+          "currency": "cad",
+          "decimals": 2
+        }
+      },
+      "featured_guests": [],
+      "role": null,
+      "waitlist_active": false,
+      "featured_city": null,
+      "calendar_api_id": "cal-eRivKmWDsR2bxYq",
+      "is_manager": true,
+      "platform": "luma",
+      "status": "approved",
+      "submitted_by_user_api_id": "usr-g6FxZJfODUaVboL",
+      "tags": []
+    },
+    {
+      "api_id": "calev-RJGV3GI2nMaqkXB",
+      "event": {
+        "api_id": "evt-VHuuSwxAUGgplkt",
+        "calendar_api_id": "cal-eRivKmWDsR2bxYq",
+        "cover_url": "https://images.lumacdn.com/event-covers/ly/ce80f4ef-7b27-4f30-84d4-9253e7479b81.png",
+        "end_at": "2026-08-29T22:00:00.000Z",
+        "event_type": "independent",
+        "hide_rsvp": false,
+        "location_type": "offline",
+        "name": "Toronto Cloud Summit 2026",
+        "one_to_one": true,
+        "recurrence_id": null,
+        "show_guest_list": false,
+        "start_at": "2026-08-29T16:00:00.000Z",
+        "timezone": "America/Toronto",
+        "url": "0xpa2rxj",
+        "user_api_id": "usr-g6FxZJfODUaVboL",
+        "visibility": "public",
+        "virtual_info": {
+          "has_access": false
+        },
+        "geo_address_info": {
+          "city": "Toronto",
+          "type": "google",
+          "region": "Ontario",
+          "address": "Northeastern University, Toronto Campus",
+          "country": "Canada",
+          "place_id": "ChIJY4j7DBI1K4gRUuidUWku87U",
+          "localized": null,
+          "city_state": "Toronto, Ontario",
+          "description": "",
+          "sublocality": "Fashion District",
+          "country_code": "CA",
+          "full_address": "Northeastern University, Toronto Campus, 375 Queen St W, Toronto, ON M5V 2A5, Canada",
+          "short_address": "375 Queen St W, Toronto",
+          "apple_maps_place_id": "I519AA9BD3445C8FE",
+          "mode": "shown"
+        },
+        "geo_address_visibility": "public",
+        "coordinate": {
+          "longitude": -79.3938694,
+          "latitude": 43.648918599999995
+        },
+        "waitlist_enabled": false,
+        "waitlist_status": "disabled"
+      },
+      "cover_image": {
+        "vibrant_color": null,
+        "colors": [
+          "#ffffff",
+          "#221e1f",
+          "#6eaedf"
+        ],
+        "palette": {
+          "neutral": [
+            {
+              "color": "#ffffff",
+              "percentage": 88.47
+            },
+            {
+              "color": "#221e1f",
+              "percentage": 6.34
+            }
+          ],
+          "vibrant": [
+            {
+              "color": "#6eaede",
+              "percentage": 4.02
+            }
+          ]
+        }
+      },
+      "calendar": {
+        "access_level": "public",
+        "api_id": "cal-eRivKmWDsR2bxYq",
+        "avatar_url": "https://images.lumacdn.com/calendars/cs/fb32f931-39df-448a-8768-0b4ee27ce169",
+        "coordinate": {
+          "longitude": -123.120738,
+          "latitude": 49.282729
+        },
+        "cover_image_url": "https://images.unsplash.com/photo-1560439514-4e9645039924?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wxMjQyMjF8MHwxfHNlYXJjaHwyfHxuZXR3b3JraW5nfGVufDB8fHx8MTcyMjI5MjA3Mnwy&ixlib=rb-4.0.3&q=80&w=1080",
+        "description_short": "Amazon AWS, Microsoft Azure and Google GCP events in Canada",
+        "event_submission_restriction": "open",
+        "geo_city": "Vancouver",
+        "geo_country": "Canada",
+        "geo_region": "British Columbia",
+        "google_measurement_id": null,
+        "instagram_handle": null,
+        "is_blocked": false,
+        "launch_status": "launched",
+        "linkedin_handle": null,
+        "luma_plus_active": true,
+        "meta_pixel_id": null,
+        "name": "Cloud Events",
+        "personal_user_api_id": null,
+        "refund_policy": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [
+                {
+                  "text": "No refunds. No Exchanges.",
+                  "type": "text"
+                }
+              ]
+            }
+          ]
+        },
+        "slug": "CloudCanada",
+        "social_image_url": null,
+        "stripe_account_id": "acct_1PxuTSE3uYeEs2Ai",
+        "tax_config": null,
+        "tiktok_handle": null,
+        "timezone": "America/Vancouver",
+        "tint_color": "#ffedc7",
+        "track_meta_ads_from_luma": false,
+        "twitter_handle": null,
+        "verified_at": "2024-06-12T21:30:46.314Z",
+        "website": "https://www.PublicCloud.ninja",
+        "youtube_handle": null,
+        "is_personal": false,
+        "personal_user": null
+      },
+      "start_at": "2026-08-29T16:00:00.000Z",
+      "hosts": [
+        {
+          "name": "Matt",
+          "api_id": "usr-g6FxZJfODUaVboL",
+          "website": "https://www.mattcarolan.com",
+          "timezone": "America/Vancouver",
+          "username": "MattCloud",
+          "bio_short": null,
+          "avatar_url": "https://images.lumacdn.com/avatars/n0/1cf35698-8753-45fc-9bb7-ad9e6c427b85",
+          "is_verified": false,
+          "tiktok_handle": null,
+          "last_online_at": "2026-01-21T04:23:26.723Z",
+          "twitter_handle": null,
+          "youtube_handle": "PublicCloudNinja",
+          "linkedin_handle": "/in/matthewcarolan",
+          "instagram_handle": "PublicCloudNinja"
+        }
+      ],
+      "guest_count": 0,
+      "ticket_count": 0,
+      "ticket_info": {
+        "price": {
+          "cents": 4900,
+          "currency": "cad",
+          "is_flexible": false
+        },
+        "is_free": false,
+        "max_price": null,
+        "is_sold_out": false,
+        "spots_remaining": null,
+        "is_near_capacity": false,
+        "require_approval": false,
+        "currency_info": {
+          "currency": "cad",
+          "decimals": 2
+        }
+      },
+      "featured_guests": [],
+      "role": null,
+      "waitlist_active": false,
+      "featured_city": null,
+      "calendar_api_id": "cal-eRivKmWDsR2bxYq",
+      "is_manager": true,
+      "platform": "luma",
+      "status": "approved",
+      "submitted_by_user_api_id": "usr-g6FxZJfODUaVboL",
+      "tags": []
+    }
+  ],
+  "has_more": false
+}

--- a/fetchData.js
+++ b/fetchData.js
@@ -1,0 +1,44 @@
+import eventsData from "./events.json" with { type: "json" };
+
+const eventsGrid = document.querySelector(".gallery-grid");
+
+for (const event of eventsData.entries) {
+  const eventCard = document.createElement("div");
+  eventCard.classList.add("event-card");
+  const image = document.createElement("img");
+  const eventInfo = document.createElement("div");
+  eventInfo.classList.add("event-info");
+  const eventHeading = document.createElement("h3");
+  const eventLocation = document.createElement("p");
+  const datePara = document.createElement("p");
+  datePara.classList.add("event-date");
+  const timePara = document.createElement("p");
+  timePara.classList.add("event-date");
+
+  const eventLink = document.createElement("a");
+  eventLink.classList.add("btn-involved");
+
+  eventHeading.textContent = event.event.name;
+  eventLocation.textContent = event.event.geo_address_info.full_address;
+  datePara.textContent = new Date(event.event.start_at).toDateString("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+  timePara.textContent = `${new Date(event.event.start_at).toLocaleTimeString("en-US")} - ${new Date(event.event.end_at).toLocaleTimeString("en-US")}`;
+  image.src = event.event.cover_url;
+  eventLink.textContent = "Details";
+  eventLink.href = `https://luma.com/${event.event.url}`;
+  eventLink.setAttribute("target", "_blank");
+
+  eventCard.appendChild(image);
+  eventInfo.appendChild(eventHeading);
+  eventInfo.appendChild(eventLocation);
+  eventInfo.appendChild(datePara);
+  eventInfo.appendChild(timePara);
+  eventInfo.appendChild(eventLink);
+  eventCard.appendChild(eventInfo);
+
+  eventsGrid.appendChild(eventCard);
+}

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link rel="icon" type="image/x-icon" href="favicon.ico">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="styles.css">
+    <script src="fetchData.js" type="module" defer></script>
 </head>
 <body>
     <!-- Navigation -->
@@ -85,52 +86,9 @@
     <!-- Events Gallery Section -->
     <section class="events-gallery" id="events">
         <h2>Events</h2>
-        <div class="gallery-grid">
-            <div class="event-card">
-                <img src="images/_DSC5513.png" alt="Cloud Summit 2025">
-                <div class="event-info">
-                    <h3>Cloud Summit 2025</h3>
-                    <p class="event-date">May 25 2025</p>
-                </div>
-            </div>
-            <div class="event-card">
-                <img src="images/_DSC5513.png" alt="Cloud Summit 2025">
-                <div class="event-info">
-                    <h3>Cloud Summit 2025</h3>
-                    <p class="event-date">May 25 2025</p>
-                </div>
-            </div>
-            <div class="event-card">
-                <img src="images/_DSC5513.png" alt="Cloud Summit 2025">
-                <div class="event-info">
-                    <h3>Cloud Summit 2025</h3>
-                    <p class="event-date">May 25 2025</p>
-                </div>
-            </div>
-            <div class="event-card">
-                <img src="images/_DSC5513.png" alt="Cloud Summit 2025">
-                <div class="event-info">
-                    <h3>Cloud Summit 2025</h3>
-                    <p class="event-date">May 25 2025</p>
-                </div>
-            </div>
-            <div class="event-card">
-                <img src="images/_DSC5513.png" alt="Cloud Summit 2025">
-                <div class="event-info">
-                    <h3>Cloud Summit 2025</h3>
-                    <p class="event-date">May 25 2025</p>
-                </div>
-            </div>
-            <div class="event-card">
-                <img src="images/_DSC5513.png" alt="Cloud Summit 2025">
-                <div class="event-info">
-                    <h3>Cloud Summit 2025</h3>
-                    <p class="event-date">May 25 2025</p>
-                </div>
-            </div>
-        </div>
+        <div class="gallery-grid"></div>
         <div class="upcoming-button">
-            <a href="#" class="btn-upcoming">Upcoming Events</a>
+            <a target="_blank" href="https://luma.com/CloudCanada?k=c" class="btn-upcoming">Upcoming Events</a>
         </div>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -1,33 +1,268 @@
+<!DOCTYPE html>
+<html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
- <meta name="keywords" content="cloud, ai, canada, united states, artifical intelligence, aws, amazon, amazon web services, web, data, google, gcp, google cloud platform, azure, microsoft, m365, o365, mvp, leader, mentor, technology, migration, mentor, devops, finops, vancouver">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Everything Cloud Technology to bring together education, sharing, networking, and supporting the local community.">
-<title>Canadian Cloud Org</title>
-<link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <meta name="keywords" content="cloud, ai, canada, aws, azure, gcp, technology, community">
+    <title>Canadian Public Cloud Association</title>
+    <link rel="icon" type="image/x-icon" href="favicon.ico">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="stylesheet" href="styles.css">
 </head>
-
 <body>
-<table width="100%" border="0">
-  <tr>
-    <td align="center" valign="middle"><p>&nbsp;</p>
-    <p>&nbsp;</p>
-    <p>&nbsp;</p>
-    <p><img src="logo.png" width="300" height="300" /></p>
-    <p><a href="https://www.meetup.com/vanawsug/" target="_blank"><img src="awsug.png" alt="AWS UG" width="70" height="70" border="0" /></a> &nbsp;
-    <a href="http://www.azurecanada.ca" target="_blank"><img src="azureug.png" alt="Azure UG" width="70" height="70" border="0" /></a> &nbsp;
-    <a href="http://www.awsday.ca" target="_blank"><img src="awsday.png" alt="AWS Day" width="70" height="70" border="0" /></a> &nbsp;
-    <a href="https://www.cloudsummit.ca" target="_blank"><img src="cloudsummit.png" alt="Cloud Summit" width="70" height="70" border="0" /></a></a> &nbsp;
-    <a href="https://discord.gg/wg372JtEK8" target="_blank"><img src="discord.png" alt="Discord" width="70" height="70" border="0" /></a> &nbsp;
-    <a href="https://www.youtube.com/channel/UCMfuz22CouuimIXngTMMZIQ" target="_blank"><img src="youtube.png" alt="YT" width="70" height="70" border="0" /></a> &nbsp;
-    <a href="https://www.instagram.com/publiccloudninja/" target="_blank"><img src="instagram.png" alt="Instagram" width="70" height="70" border="0" /></a> &nbsp;
-   <a href="http://www.linkedin.com/company/canadiancloud" target="_blank"><img src="linkedin.png" alt="Linkedin" width="70" height="70" border="0" /></a> &nbsp;
-    <a href="https://cpca-events.atlassian.net/wiki/spaces/awsday/overview" target="_blank"><img src="organizers.png" width="70" height="70" border="0" /></a></p>
+    <!-- Navigation -->
+    <nav>
+        <div class="nav-logo">
+            <img src="logo.png" alt="CPCA Logo">
+            <span>CPCA</span>
+        </div>
+        <div class="hamburger" id="hamburger">
+            <span></span>
+            <span></span>
+            <span></span>
+        </div>
+        <ul class="nav-menu" id="navMenu">
+            <li><a href="#about">About</a></li>
+            <li><a href="#events">Events</a></li>
+            <li><a href="#involved">Get Involved</a></li>
+        </ul>
+    </nav>
 
+    <!-- Hero Section -->
+    <section class="hero">
+        <div class="hero-content">
+            <h1>Canadian Public<br>Cloud Association</h1>
+            <p>As a non-profit organization, our purpose is to bring together & educate the local tech community about the cloud and support our local community through charity.</p>
+            
+            <div class="button-container">
+                <a href="https://www.cloudsummit.ca" class="btn" target="_blank">Cloud Summit</a>
+                <a href="https://www.meetup.com/vanawsug/" class="btn" target="_blank">AWS Events</a>
+                <a href="http://www.azurecanada.ca" class="btn" target="_blank">Azure Events</a>
+                <a href="#events" class="btn">Cloud Events</a>
+            </div>
+        </div>
+    </section>
 
+    <!-- Statistics Section -->
+    <section class="stats">
+        <div class="stat-box">
+            <div class="stat-item">
+                <div class="stat-number" data-target="14">0</div>
+                <div class="stat-label">Total Events</div>
+            </div>
+            <div class="stat-item">
+                <div class="stat-number" data-target="1800">0</div>
+                <div class="stat-label">Total Attendees</div>
+            </div>
+            <div class="stat-item">
+                <div class="stat-number" data-target="4000">0</div>
+                <div class="stat-label">Total Members</div>
+            </div>
+            <div class="stat-item">
+                <div class="stat-number" data-target="10000" data-prefix="$">0</div>
+                <div class="stat-label">Total Charity Raised</div>
+            </div>
+        </div>
+    </section>
 
-    <p>&nbsp;</p>
-    <p>&nbsp;</p></td>
-  </tr>
-</table>
+    <!-- About Section -->
+    <section class="about" id="about">
+        <div class="about-content">
+            <div class="about-text">
+                <h2>Canadian Public Cloud Association Sed ut unde perspiciatis unde omnis iste natus</h2>
+                <p>Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem.</p>
+                <p>Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur?</p>
+                <p>Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis ut enim ad minima veniam, quis nostrum exercitationem ullam corporis</p>
+                <p>Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis</p>
+            </div>
+            <div class="about-image">
+                <img src="images/_DSC5513.png" alt="CPCA Event">
+            </div>
+        </div>
+    </section>
+
+    <!-- Events Gallery Section -->
+    <section class="events-gallery" id="events">
+        <h2>Events</h2>
+        <div class="gallery-grid">
+            <div class="event-card">
+                <img src="images/_DSC5513.png" alt="Cloud Summit 2025">
+                <div class="event-info">
+                    <h3>Cloud Summit 2025</h3>
+                    <p class="event-date">May 25 2025</p>
+                </div>
+            </div>
+            <div class="event-card">
+                <img src="images/_DSC5513.png" alt="Cloud Summit 2025">
+                <div class="event-info">
+                    <h3>Cloud Summit 2025</h3>
+                    <p class="event-date">May 25 2025</p>
+                </div>
+            </div>
+            <div class="event-card">
+                <img src="images/_DSC5513.png" alt="Cloud Summit 2025">
+                <div class="event-info">
+                    <h3>Cloud Summit 2025</h3>
+                    <p class="event-date">May 25 2025</p>
+                </div>
+            </div>
+            <div class="event-card">
+                <img src="images/_DSC5513.png" alt="Cloud Summit 2025">
+                <div class="event-info">
+                    <h3>Cloud Summit 2025</h3>
+                    <p class="event-date">May 25 2025</p>
+                </div>
+            </div>
+            <div class="event-card">
+                <img src="images/_DSC5513.png" alt="Cloud Summit 2025">
+                <div class="event-info">
+                    <h3>Cloud Summit 2025</h3>
+                    <p class="event-date">May 25 2025</p>
+                </div>
+            </div>
+            <div class="event-card">
+                <img src="images/_DSC5513.png" alt="Cloud Summit 2025">
+                <div class="event-info">
+                    <h3>Cloud Summit 2025</h3>
+                    <p class="event-date">May 25 2025</p>
+                </div>
+            </div>
+        </div>
+        <div class="upcoming-button">
+            <a href="#" class="btn-upcoming">Upcoming Events</a>
+        </div>
+    </section>
+
+    <!-- Get Involved Section -->
+    <section class="get-involved" id="involved">
+        <h2>Get Involved</h2>
+        <div class="involved-grid">
+            <div class="involved-card">
+                <div class="involved-icon"><i class="fas fa-handshake"></i></div>
+                <h3>Become a Sponsor</h3>
+                <p>Become a sponsor and help us build the future of local cloud communities</p>
+                <a href="#" class="btn-involved">Join Us</a>
+            </div>
+            <div class="involved-card">
+                <div class="involved-icon"><i class="fas fa-microphone"></i></div>
+                <h3>Be a Speaker</h3>
+                <p>Interested in speaking at our upcoming event? Let's get in touch!</p>
+                <a href="#" class="btn-involved">Contact</a>
+            </div>
+            <div class="involved-card">
+                <div class="involved-icon"><i class="fas fa-users"></i></div>
+                <h3>Join Community</h3>
+                <p>Join our discord group to stay connected</p>
+                <a href="#" class="btn-involved">Join Us</a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="footer">
+        <div class="footer-content">
+            <!-- Left Section: Logo & Description -->
+            <div class="footer-section">
+                <div class="footer-logo">
+                    <img src="logo.png" alt="CPCA Logo">
+                    <span>CPCA</span>
+                </div>
+                <p class="footer-description">We bring together & educate the local tech community about the cloud and support our local community</p>
+            </div>
+
+            <!-- Middle Section: Quick Links -->
+            <div class="footer-section">
+                <h3>Quick Links</h3>
+                <ul class="footer-links">
+                    <li><a href="#about">About</a></li>
+                    <li><a href="#events">Events</a></li>
+                    <li><a href="#events">Upcoming Events</a></li>
+                    <li><a href="#involved">Get Involved</a></li>
+                    <li><a href="https://www.cloudsummit.ca" target="_blank">Cloud Summit</a></li>
+                    <li><a href="https://www.awsday.ca" target="_blank">AWS Community Day</a></li>
+                    <li><a href="https://www.hackerrivals.com" target="_blank">Hackathon Partner</a></li>
+                </ul>
+            </div>
+
+            <!-- Right Section: Contacts & Socials -->
+            <div class="footer-section">
+                <div class="footer-contacts">
+                    <h3>Contacts</h3>
+                    <p><a href="mailto:connect@canadiancloud.org" target="_blank"><i class="fas fa-envelope"></i> connect@canadiancloud.org</a></p>
+                </div>
+                <div class="footer-socials">
+                    <h3>Socials</h3>
+                    <div class="social-icons">
+                        <a href="https://www.linkedin.com/company/canadiancloud" target="_blank"><i class="fab fa-linkedin"></i></a>
+                        <a href="https://www.instagram.com/canadiancloudninja/" target="_blank"><i class="fab fa-instagram"></i></a>
+                        <a href="https://discord.gg/wg372JtEK8" target="_blank"><i class="fab fa-discord"></i></a>
+                        <a href="https://www.youtube.com/channel/UCMfuz22CouuimIXngTMMZIQ" target="_blank"><i class="fab fa-youtube"></i></a>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2026 Canadian Public Cloud Association. All rights reserved.</p>
+        </div>
+    </footer>
+    <script>
+        // Hamburger menu toggle
+        const hamburger = document.getElementById('hamburger');
+        const navMenu = document.getElementById('navMenu');
+
+        hamburger.addEventListener('click', () => {
+            hamburger.classList.toggle('active');
+            navMenu.classList.toggle('active');
+        });
+
+        // Close menu when a link is clicked
+        const navLinks = navMenu.querySelectorAll('a');
+        navLinks.forEach(link => {
+            link.addEventListener('click', () => {
+                hamburger.classList.remove('active');
+                navMenu.classList.remove('active');
+            });
+        });
+
+        // Counter animation for statistics
+        function animateCounters() {
+            const statNumbers = document.querySelectorAll('.stat-number');
+            
+            statNumbers.forEach(element => {
+                const target = parseInt(element.dataset.target);
+                const prefix = element.dataset.prefix || '';
+                let current = 0;
+                const increment = Math.ceil(target / 50);
+                
+                const timer = setInterval(() => {
+                    current += increment;
+                    if (current >= target) {
+                        current = target;
+                        clearInterval(timer);
+                        // Format number with commas
+                        element.textContent = prefix + current.toLocaleString() + '+';
+                    } else {
+                        element.textContent = prefix + current.toLocaleString();
+                    }
+                }, 30);
+            });
+        }
+        
+        // Trigger animation when stats section comes into view
+        const observer = new IntersectionObserver(entries => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    animateCounters();
+                    observer.unobserve(entry.target);
+                }
+            });
+        });
+        
+        const statsSection = document.querySelector('.stats');
+        if (statsSection) {
+            observer.observe(statsSection);
+        }
+    </script>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,16 @@
+import fs from "node:fs";
+
+const response = await fetch(
+  "https://api.lu.ma/calendar/get-items?calendar_api_id=cal-eRivKmWDsR2bxYq&pagination_limit=20&period=future",
+  {
+    method: "GET",
+  },
+);
+
+if (!response.ok) {
+  throw new Error(`Response status ${response.status}`);
+}
+
+const result = await response.json();
+
+fs.writeFileSync("events.json", JSON.stringify(result, null, 2));

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,810 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    color: #333;
+}
+
+/* Navigation */
+nav {
+    background-color: #430000;
+    padding: 1rem 2rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.nav-logo {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.nav-logo img {
+    height: 50px;
+    width: auto;
+}
+
+.nav-logo span {
+    color: white;
+    font-weight: bold;
+    font-size: 1.1rem;
+}
+
+.nav-menu {
+    display: flex;
+    gap: 2rem;
+    list-style: none;
+}
+
+.nav-menu a {
+    color: white;
+    text-decoration: none;
+    font-weight: 500;
+    transition: opacity 0.3s ease;
+}
+
+.nav-menu a:hover {
+    opacity: 0.8;
+}
+
+/* Hamburger Menu */
+.hamburger {
+    display: none;
+    flex-direction: column;
+    cursor: pointer;
+    gap: 6px;
+}
+
+.hamburger span {
+    width: 25px;
+    height: 3px;
+    background-color: white;
+    border-radius: 3px;
+    transition: all 0.3s ease;
+}
+
+.hamburger.active span:nth-child(1) {
+    transform: rotate(45deg) translate(10px, 10px);
+}
+
+.hamburger.active span:nth-child(2) {
+    opacity: 0;
+}
+
+.hamburger.active span:nth-child(3) {
+    transform: rotate(-45deg) translate(7px, -7px);
+}
+
+/* Hero Section */
+.hero {
+    background: linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4)), url('images/_DSC5513.png') center/cover;
+    color: white;
+    padding: 250px 2rem 100px 2rem;
+    min-height: 500px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
+.hero-content {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 2rem;
+    text-align: left;
+}
+
+.hero h1 {
+    font-size: 6.5rem;
+    margin-bottom: 1rem;
+    font-weight: bold;
+    line-height: 1.2;
+}
+
+.hero p {
+    font-size: 1.2rem;
+    margin-bottom: 2rem;
+    /* max-width: 600px; */
+    line-height: 1.6;
+}
+
+/* Buttons */
+.button-container {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 3rem;
+    width: 100%;
+    margin-bottom: 0;
+}
+
+.btn {
+    background-color: #39DEFF;
+    color: #000;
+    padding: 15px 20px;
+    border: none;
+    border-radius: 15px;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    text-decoration: none;
+    display: block;
+    text-align: center;
+    transition: background-color 0.3s ease;
+}
+
+.btn:hover {
+    background-color: #3498db;
+}
+
+/* Stats Section */
+.stats {
+    background-color: #430000;
+    padding: 3rem 2rem;
+    display: flex;
+    justify-content: center;
+    margin-top: -60px;
+    position: relative;
+    z-index: 10;
+}
+
+.stat-box {
+    background-color: white;
+    padding: 4rem 3rem;
+    border-radius: 30px;
+    text-align: center;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    display: flex;
+    align-items: center;
+    gap: 3rem;
+    max-width: 1200px;
+    width: 100%;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.stat-item {
+    flex: 1;
+    min-width: 150px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+}
+
+.stat-item:not(:last-child)::after {
+    content: '';
+    position: absolute;
+    right: -1.5rem;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 2px;
+    height: 50px;
+    background-color: #ddd;
+}
+
+.stat-number {
+    font-size: 2.7rem;
+    font-weight: bold;
+    color: #000;
+    margin-bottom: 0.3rem;
+}
+
+.stat-label {
+    color: #666;
+    font-size: 1.2rem;
+    font-weight: 500;
+}
+
+/* About Section */
+.about {
+    background-color: #430000;
+    color: white;
+    padding: 4rem 2rem;
+}
+
+.about-content {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 2rem;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 3rem;
+    align-items: center;
+}
+
+.about-text h2 {
+    font-size: 1.8rem;
+    margin-bottom: 1.5rem;
+    line-height: 1.4;
+}
+
+.about-text p {
+    font-size: 1rem;
+    margin-bottom: 1rem;
+    line-height: 1.6;
+    color: #ddd;
+}
+
+.about-image img {
+    width: 100%;
+    border-radius: 10px;
+}
+
+/* Events Gallery Section */
+.events-gallery {
+    background-color: #430000;
+    color: white;
+    padding: 4rem 2rem;
+}
+
+.events-gallery h2 {
+    text-align: center;
+    font-size: 2.5rem;
+    margin-bottom: 3rem;
+}
+
+.gallery-grid {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 2rem;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 2rem;
+    margin-bottom: 3rem;
+}
+
+.event-card {
+    background-color: rgba(255, 255, 255, 0.05);
+    border-radius: 15px;
+    overflow: hidden;
+    transition: transform 0.3s ease;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.event-card:hover {
+    transform: translateY(-5px);
+}
+
+.event-card img {
+    width: 100%;
+    height: 250px;
+    object-fit: cover;
+}
+
+.event-info {
+    padding: 1.5rem;
+    background-color: #9B0000;
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+}
+
+.event-info h3 {
+    font-size: 1.1rem;
+    margin-bottom: 0.5rem;
+}
+
+.event-date {
+    font-size: 0.9rem;
+    color: #aaa;
+}
+
+.upcoming-button {
+    text-align: center;
+}
+
+.btn-upcoming {
+    background-color: #39DEFF;
+    color: #000;
+    padding: 12px 30px;
+    border: none;
+    border-radius: 15px;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    text-decoration: none;
+    display: inline-block;
+    transition: background-color 0.3s ease;
+}
+
+.btn-upcoming:hover {
+    background-color: #2fc9e6;
+}
+
+/* Get Involved Section */
+.get-involved {
+    background-color: #430000;
+    color: white;
+    padding: 4rem 2rem;
+}
+
+.get-involved h2 {
+    text-align: center;
+    font-size: 2.5rem;
+    margin-bottom: 3rem;
+}
+
+.involved-grid {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 2rem;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 2rem;
+}
+
+.involved-card {
+    background-color: white;
+    color: #000;
+    padding: 2.5rem 2rem;
+    border-radius: 40px;
+    text-align: center;
+    transition: transform 0.3s ease;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.involved-card:hover {
+    transform: translateY(-10px);
+}
+
+.involved-icon {
+    font-size: 4.5rem;
+    margin-bottom: 1.5rem;
+    line-height: 1;
+}
+
+.involved-card h3 {
+    font-size: 1.4rem;
+    margin-bottom: 1rem;
+    color: #000;
+    font-weight: 700;
+}
+
+.involved-card p {
+    font-size: 0.95rem;
+    margin-bottom: 2rem;
+    line-height: 1.6;
+    color: #333;
+}
+
+.btn-involved {
+    background-color: #39DEFF;
+    color: #000;
+    padding: 10px 25px;
+    border: none;
+    border-radius: 15px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    text-decoration: none;
+    display: inline-block;
+    transition: background-color 0.3s ease;
+    margin-top: auto;
+    align-self: center;
+}
+
+.btn-involved:hover {
+    background-color: #2fc9e6;
+}
+
+/* Footer */
+.footer {
+    background-color: #1a0000;
+    color: white;
+    padding: 4rem 2rem 1.5rem 2rem;
+}
+
+.footer-content {
+    max-width: 1400px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 3rem;
+}
+
+.footer-section {
+    display: flex;
+    flex-direction: column;
+}
+
+.footer-section h3 {
+    font-size: 1.2rem;
+    margin-bottom: 1.5rem;
+    font-weight: 600;
+}
+
+/* Footer Logo Section */
+.footer-logo {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.8rem;
+    margin-bottom: 1.5rem;
+}
+
+.footer-logo img {
+    height: 150px;
+    width: auto;
+    filter: brightness(0) invert(1);
+}
+
+.footer-logo span {
+    font-weight: bold;
+    font-size: 2.1rem;
+    padding-left: 1em;
+    margin-top: -1em;
+}
+
+.footer-description {
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: #ccc;
+}
+
+/* Footer Links */
+.footer-links {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+}
+
+.footer-links a {
+    color: #ccc;
+    text-decoration: none;
+    font-size: 0.95rem;
+    transition: color 0.3s ease;
+}
+
+.footer-links a:hover {
+    color: #39DEFF;
+}
+
+/* Footer Contacts */
+.footer-contacts p {
+    font-size: 0.95rem;
+    margin-bottom: 1.5rem;
+}
+
+.footer-contacts a {
+    color: #ccc;
+    text-decoration: none;
+    transition: color 0.3s ease;
+}
+
+.footer-contacts a:hover {
+    color: #39DEFF;
+}
+
+/* Footer Socials */
+.social-icons {
+    display: flex;
+    gap: 1.5rem;
+    font-size: 1.3rem;
+}
+
+.social-icons a {
+    color: white;
+    text-decoration: none;
+    transition: transform 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    background-color: rgba(255, 255, 255, 0.1);
+    border-radius: 50%;
+}
+
+.social-icons a:hover {
+    transform: scale(1.1);
+    background-color: #39DEFF;
+    color: #000;
+}
+
+/* Footer Bottom */
+.footer-bottom {
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    margin-top: 2rem;
+    padding-top: 1.5rem;
+    text-align: center;
+}
+
+.footer-bottom p {
+    font-size: 0.9rem;
+    color: #999;
+}
+
+/* Responsive */
+@media (max-width: 1024px) {
+    .footer-content {
+        grid-template-columns: 1fr 1fr;
+        gap: 2rem;
+    }
+
+    .gallery-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .button-container {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 1.5rem;
+    }
+}
+
+@media (max-width: 768px) {
+    /* Navigation */
+    nav {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+    }
+
+    .hamburger {
+        display: flex;
+    }
+
+    .nav-menu {
+        position: absolute;
+        top: 70px;
+        left: 0;
+        width: 100%;
+        background-color: #430000;
+        flex-direction: column;
+        gap: 0;
+        list-style: none;
+        padding: 1rem 2rem;
+        display: none;
+        z-index: 100;
+    }
+
+    .nav-menu.active {
+        display: flex;
+    }
+
+    .nav-menu li {
+        padding: 0.8rem 0;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    }
+
+    .nav-menu li:last-child {
+        border-bottom: none;
+    }
+
+    .nav-menu a {
+        font-size: 0.9rem;
+    }
+
+    /* Hero Section */
+    .hero {
+        padding: 150px 1rem 80px 1rem;
+    }
+
+    .hero h1 {
+        font-size: 2.5rem;
+        margin-bottom: 1rem;
+    }
+
+    .hero p {
+        font-size: 0.95rem;
+        margin-bottom: 1.5rem;
+    }
+
+    .button-container {
+        grid-template-columns: 1fr 1fr;
+        gap: 1rem;
+        width: 100%;
+    }
+
+    .btn {
+        padding: 10px 16px;
+        font-size: 0.85rem;
+    }
+
+    /* Stats */
+    .stat-box {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 2rem 1rem;
+        padding: 2rem 1.5rem;
+    }
+
+    .stat-item {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        min-width: auto;
+    }
+
+    .stat-item:not(:last-child)::after {
+        display: none;
+    }
+
+    .stat-number {
+        font-size: 2rem;
+    }
+
+    .stat-label {
+        font-size: 1rem;
+    }
+
+    /* About Section */
+    .about {
+        padding: 2rem 2rem 4rem 2rem;
+    }
+
+    .about-content {
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+        padding: 0 1rem;
+    }
+
+    .about-text h2 {
+        font-size: 1.4rem;
+    }
+
+    /* Events Gallery */
+    .events-gallery {
+        padding: 2rem 2rem 4rem 2rem;
+    }
+
+    .gallery-grid {
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+        padding: 0 1rem;
+    }
+
+    .events-gallery h2 {
+        font-size: 1.8rem;
+    }
+
+    /* Get Involved */
+    .get-involved {
+        padding: 2rem 2rem 4rem 2rem;
+    }
+
+    .involved-grid {
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+        padding: 0 1rem;
+    }
+
+    .get-involved h2 {
+        font-size: 1.8rem;
+    }
+
+    .involved-icon {
+        font-size: 3rem;
+    }
+
+    /* Footer */
+    .footer-content {
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+    }
+
+    .footer-section {
+        text-align: left;
+    }
+
+    .footer-logo {
+        align-items: flex-start;
+    }
+
+    .footer-logo img {
+        height: 65px;
+    }
+
+    .footer-logo span {
+        font-size: 0.9rem;
+    }
+
+    .footer-links {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 0.5rem 1rem;
+        text-align: left;
+    }
+
+    .social-icons {
+        justify-content: flex-start;
+    }
+}
+
+@media (max-width: 480px) {
+    /* Hero Section */
+    .hero {
+        padding: 120px 1rem 60px 1rem;
+    }
+
+    .hero h1 {
+        font-size: 1.8rem;
+    }
+
+    .hero p {
+        font-size: 0.9rem;
+    }
+
+    .button-container {
+        grid-template-columns: 1fr 1fr;
+        gap: 0.8rem;
+    }
+
+    .btn {
+        padding: 10px 14px;
+        font-size: 0.8rem;
+    }
+
+    /* Navigation */
+    .nav-logo span {
+        font-size: 0.9rem;
+    }
+
+    /* Stats */
+    .stat-box {
+        padding: 1.5rem 1rem;
+        gap: 1rem;
+    }
+
+    .stat-item {
+        min-width: 80px;
+    }
+
+    .stat-number {
+        font-size: 1.3rem;
+    }
+
+    .stat-label {
+        font-size: 0.8rem;
+    }
+
+    /* Text Sections */
+    .about-text h2,
+    .events-gallery h2,
+    .get-involved h2 {
+        font-size: 2rem;
+        margin-bottom: 1.5rem;
+    }
+
+    .involved-card {
+        padding: 1rem 0.75rem;
+        border-radius: 20px;
+    }
+
+    .involved-icon {
+        font-size: 2rem;
+        margin-bottom: 0.8rem;
+    }
+
+    .involved-card h3 {
+        font-size: 1rem;
+        margin-bottom: 0.6rem;
+    }
+
+    .involved-card p {
+        font-size: 0.8rem;
+        margin-bottom: 0.8rem;
+        line-height: 1.4;
+    }
+
+    .btn-involved {
+        padding: 8px 16px;
+        font-size: 0.8rem;
+    }
+}


### PR DESCRIPTION
**Purpose**
To ensure Canadian Cloud's website events are updated consistently from Luma

**Details**
- Add a `index.js` script. This script does the following:
  1. Fetches from the `https://api.lu.ma` end point and return the most recent events from Canadian Cloud Luma page
  2. Write to a JSON file called `events.json` so that client side can render
- Add a `fetchData.js` script that reads from `events.json`
- Add a GitHub workflow that setup NodeJS to run every 24 hours, which does:
  1. Run `index.js`
  2. Check if there is any difference in `events.json`
  3. If there are, that means the Luma page had a new event. This will be commited and automatically pushed to this repo
  4. If not, does nothing

**Additional Comments**
This feature is inspired by how VanJS handle updates from their Luma page (see [this commit](https://github.com/VanJS/vanjs.github.io/commit/ff2c1a5985df424f3c3da145c5e77f93a02aa9c4))